### PR TITLE
Remove foosummaries array from Program.cs

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -18,10 +18,6 @@ var newSummaries = new[]
     "Brrrrr", "Yikes", "Frozen", "Hot", "Ouch", "StopIt"
 };
 
-var foosummaries = new[]
-{
-    "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"


### PR DESCRIPTION
This pull request makes a small cleanup to the `api/Program.cs` file by removing the unused `foosummaries` array, which helps reduce clutter and improve code maintainability.Removed the foosummaries array from Program.cs.